### PR TITLE
Use provided transition on cache hit

### DIFF
--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -316,14 +316,9 @@ public struct CachedAsyncImage<Content>: View where Content: View {
     private func load() async {
         do {
             if let urlRequest = urlRequest {
-                let (image, metrics) = try await remoteImage(from: urlRequest, session: urlSession)
-                if metrics.transactionMetrics.last?.resourceFetchType == .localCache {
-                    // WARNING: This does not behave well when the url is changed with another
+                let (image, _) = try await remoteImage(from: urlRequest, session: urlSession)
+                withAnimation(transaction.animation) {
                     phase = .success(image)
-                } else {
-                    withAnimation(transaction.animation) {
-                        phase = .success(image)
-                    }
                 }
             } else {
                 withAnimation(transaction.animation) {


### PR DESCRIPTION
When provided with an URL that ends up being redirected (301), no cache hit occurs during initialization, as `URLCache.cachedResponse` expects the redirected URL to be provided instead.
This leads to `_phase` being set to `.empty`, even though the ensuing `.load` call will result in a cache hit, because `URLSession.data` _does_ behave properly.

... that's my theory, at least 😬 

I saw, that f24cfe71158f428e9a396a19335221f0fe19e10e did away with animating on cache hit. 
What was the reason for that change?