### PR TITLE
Fix caching behavior

### DIFF
--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -317,7 +317,8 @@ public struct CachedAsyncImage<Content>: View where Content: View {
         do {
             if let urlRequest = urlRequest {
                 let (image, metrics) = try await remoteImage(from: urlRequest, session: urlSession)
-                if metrics.transactionMetrics.last?.resourceFetchType == .localCache {
+                // NOTE: There is 2 transactions metrics if the request cache policy is the default one, only the first transaction concern the cached resource https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy/useprotocolcachepolicy
+                if metrics.transactionMetrics.first?.resourceFetchType == .localCache {
                     // WARNING: This does not behave well when the url is changed with another
                     phase = .success(image)
                 } else {


### PR DESCRIPTION
Fixing wrong cache behavior, in case of urlRequest using default cache policy, there is 2 transactions metrics and the first one concerns the cache resource according to Apple: https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy/useprotocolcachepolicy

Others policies have only one metrics.

Related issue: https://github.com/lorenzofiamingo/swiftui-cached-async-image/issues/24