### PR TITLE
fix: non-sendable

### DIFF
--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -79,7 +79,7 @@ public struct CachedAsyncImage<Content>: View where Content: View {
     
     public var body: some View {
         content(phase)
-            .task(id: urlRequest, load)
+            .task(id: urlRequest) { await load() }
     }
     
     /// Loads and displays an image from the specified URL.
@@ -312,7 +312,6 @@ public struct CachedAsyncImage<Content>: View where Content: View {
         }
     }
     
-    @Sendable
     private func load() async {
         do {
             if let urlRequest = urlRequest {


### PR DESCRIPTION
This "solves" the warning on the `load()` method, see #27:

> Instance methods of non-Sendable types cannot be marked as 'https://github.com/sendable'; this is an error in Swift 6

However, I am unsure of the implications of removing the `@Sendable` attribute 🤷‍♂️.

Solution provided by https://github.com/lorenzofiamingo/swiftui-cached-async-image/issues/27#issuecomment-2114089315 .