### PR TITLE
Use a URLSessionConfiguration that can be configured by app

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ extension URLCache {
 
 Remember when setting the cache the response (in this case our image) must be no larger than about 5% of the disk cache (See [this discussion](https://developer.apple.com/documentation/foundation/nsurlsessiondatadelegate/1411612-urlsession#discussion)).
 
+You can also modify the `URLSessionConfiguration` used by `CachedAsyncImage` via `URLSessionConfiguration.cachedAsyncImage`:
+
+```swift
+URLSessionConfiguration.cachedAsyncImage.protocolClasses = [MyContentProtocol.self]
+```
+
 ## Installation
 
 1. In Xcode, open your project and navigate to **File** → **Swift Packages** → **Add Package Dependency...**

--- a/Sources/CachedAsyncImage/CachedAsyncImage.swift
+++ b/Sources/CachedAsyncImage/CachedAsyncImage.swift
@@ -294,7 +294,7 @@ public struct CachedAsyncImage<Content>: View where Content: View {
     ///   - content: A closure that takes the load phase as an input, and
     ///     returns the view to display for the specified phase.
     public init(urlRequest: URLRequest?, urlCache: URLCache = .shared, scale: CGFloat = 1, transaction: Transaction = Transaction(), @ViewBuilder content: @escaping (AsyncImagePhase) -> Content) {
-        let configuration = URLSessionConfiguration.default
+        let configuration = URLSessionConfiguration.cachedAsyncImage
         configuration.urlCache = urlCache
         self.urlRequest = urlRequest
         self.urlSession =  URLSession(configuration: configuration)
@@ -402,5 +402,23 @@ private extension URLSession {
         let controller = URLSessionTaskController()
         let (data, response) = try await data(for: request, delegate: controller)
         return (data, response, controller.metrics!)
+    }
+}
+
+// MARK: - URLSessionConfiguration
+
+@MainActor
+private var urlSessionConfig = URLSessionConfiguration.default
+extension URLSessionConfiguration {
+
+    /// Default configuration used by `CachedAsyncImage`.
+    @MainActor
+    public static var cachedAsyncImage: URLSessionConfiguration {
+        get {
+            urlSessionConfig
+        }
+        set {
+            urlSessionConfig = newValue
+        }
     }
 }


### PR DESCRIPTION
Apps may need custom URLSessionConfiguration in order to function properly. For example, if it uses a custom NSURLProtocol to load image, it needs to set `protocolClasses` or content loaded by those custom protocols won't load.

`CachedAsyncImage` starts its sessions using `URLSessionConfiguration.default`, but because it always returns a copy, that can't be used by the app to configure the default configuration with its own unique requirements. In order to support custom configuration, have `CachedAsyncImage` use an internal copy of the default config that is exposed to the app via `URLSessionConfiguration.cachedAsyncImage` that can be modified or set. 