### PR TITLE
Add comma to "package" instance

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .iOS(.v13),
         .macOS(.v10_15),
         .tvOS(.v13),
-        .watchOS(.v6)
+        .watchOS(.v6),
         .visionOS(.v1)
     ],
     products: [


### PR DESCRIPTION
Comma at end of preceding value is needed to add visionOS to the list of values instead of as a static member (right now it results in a parsing error in Xcode at package fetch time).