### PR TITLE
fix: visionOS is available from 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.9
 
 import PackageDescription
 


### PR DESCRIPTION
#38 added visionOS, but visionOS is available from Swift tools version 5.9

fix #41 