### PR TITLE
NAPPS-7085: Improved image cache thread loading

### DIFF
--- a/CachedAsyncImage.podspec
+++ b/CachedAsyncImage.podspec
@@ -1,0 +1,24 @@
+Pod::Spec.new do |s|
+
+  s.name         = "CachedAsyncImage"
+  s.version      = "2.1.2"
+  s.summary      = "CachedAsyncImage is the simplest way to add cache to your AsyncImage."
+
+  s.description  = <<-DESC
+  CachedAsyncImage is the simplest way to add cache to your AsyncImage.
+                   DESC
+
+  s.homepage     = "https://github.com/GannettDigital/swiftui-cached-async-image"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.author       = { "Lorenzo Fiamingo" => "https://github.com/lorenzofiamingo" }
+
+  s.ios.deployment_target = "13.0"
+  s.tvos.deployment_target = "13.0"
+  s.osx.deployment_target = "10.15"
+  s.watchos.deployment_target = "6.0"
+
+  s.source       = { :git => "https://github.com/GannettDigital/swiftui-cached-async-image.git", :tag => "#{s.version}" }
+
+  s.source_files  = "Sources/**/*"
+
+end

--- a/CachedAsyncImage.podspec
+++ b/CachedAsyncImage.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                    DESC
 
   s.homepage     = "https://github.com/GannettDigital/swiftui-cached-async-image"
-  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.license      = { :type => "MIT", :file => "LICENSE.md" }
   s.author       = { "Lorenzo Fiamingo" => "https://github.com/lorenzofiamingo" }
 
   s.ios.deployment_target = "13.0"


### PR DESCRIPTION
1. Bumps the swiftui-cached-async-image submodule to 2.1.3.
2. Shares one URLSession for the URLCache.shared case instead of creating one per view.
3. Removes the synchronous cached-image lookup in init, which decoded on the main thread during view construction.
4. Decodes images with byPreparingForDisplay() off the main thread before handing them to SwiftUI.
5. Adds cancellation checks so a cancelled load never publishes a phase.